### PR TITLE
Added Snippet for Edge Insets Symmetric

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,35 +12,43 @@ I'm working hard to select all the day to day widgets, so wait for more!.
 
 ### Snippets
 
-| Snippet     | Renders                                                 |
-| ----------- | ------------------------------------------------------- |
-| `fscaff`    | Scaffold widget snippet                                 |
-| `fstfulapp` | StatefulWidget snippet App                              |
-| `fstless`   | StatelessWidget snippet                                 |
-| `fedgall`   | EdgeInsets widget snippet with named constructor `all`  |
-| `fedgonly`  | EdgeInsets widget snippet with named constructor `only` |
-| `ftxt`      | Text widget snippet                                     |
-| `dinvar`    | Dart Public Instance variable snippet                   |
-| `dprinvar`  | Dart Private instance variable snippet                  |
-| `finitlf`   | Flutter initState lifecycle method snippet              |
-| `dprmt`     | Dart private method snippet                             |
-| `dopnctor`  | Dart optional named parameters constructor snippet      |
-| `fic`       | Flutter Icon widget snippet                             |
-| `fcont`     | Flutter Container widget snippet                        |
-| `fcent`     | Flutter Center widget snippet                           |
-| `frow`      | Flutter Row widget snippet                              |
-| `fcol`      | Flutter Column widget snippet                           |
-| `fex`       | Expand widget snippet                                   |
-| `fszbw`     | SizedBox widget snippet with just width argument        |
-| `fszbh`     | SizedBox widget snippet with just height argument       |
-| `fszb`      | SizedBox widget with width and height arguments         |
+| Snippet     | Renders                                                                              |
+| ----------- | ------------------------------------------------------------------------------------ |
+| `fscaff`    | Scaffold widget snippet                                                              |
+| `fstfulapp` | StatefulWidget snippet App                                                           |
+| `fstless`   | StatelessWidget snippet                                                              |
+| `fedgall`   | EdgeInsets widget snippet with named constructor `all`                               |
+| `fedgonly`  | EdgeInsets widget snippet with named constructor `only`                              |
+| `ftxt`      | Text widget snippet                                                                  |
+| `dinvar`    | Dart Public Instance variable snippet                                                |
+| `dprinvar`  | Dart Private instance variable snippet                                               |
+| `finitlf`   | Flutter initState lifecycle method snippet                                           |
+| `dprmt`     | Dart private method snippet                                                          |
+| `dopnctor`  | Dart optional named parameters constructor snippet                                   |
+| `fic`       | Flutter Icon widget snippet                                                          |
+| `fcont`     | Flutter Container widget snippet                                                     |
+| `fcent`     | Flutter Center widget snippet                                                        |
+| `frow`      | Flutter Row widget snippet                                                           |
+| `fcol`      | Flutter Column widget snippet                                                        |
+| `fex`       | Expand widget snippet                                                                |
+| `fszbw`     | SizedBox widget snippet with just width argument                                     |
+| `fszbh`     | SizedBox widget snippet with just height argument                                    |
+| `fszb`      | SizedBox widget with width and height arguments                                      |
+| `fedgsym`   | EdgeInsets widget with named constructor `symmetric`                                 |
+| `fedgsymv`   | EdgeInsets widget with named constructor `symmetric` with `vertical` parameter      |
+| `fedgsymh`   | EdgeInsets widget with named constructor `symmetric` with `horizontal` parameter    |
 
 ## Release Notes
+
+### 0.0.3
+
+- Fixes
+  - Typos
 
 ### 0.0.2
 
 - New Snippets:
-  - fex - xpand widget snippet
+  - fex - Expand widget snippet
   - fszbw - SizedBox widget snippet with just width argument
   - fszbh - SizedBox widget snippet with just height argument
   - fszb - SizedBox widget with width and height arguments

--- a/snippets/dart.json
+++ b/snippets/dart.json
@@ -204,5 +204,26 @@
       "EdgeInsets.only(${1})${0}"
     ],
     "description": "EdgeInsets widget snippet with named constructor `only`"
+  },
+  "EdgeInsets widget snippet with symmetric contructor `symmetric`": {
+    "prefix": "fedgsym",
+    "body": [
+      "EdgeInsets.symmetric(vertical: ${1:8.0}, horizontal: ${2:8.0},)${0}"
+    ],
+    "description": "EdgeInsets widget snippet with named constructor `symmetric`"
+  },
+  "EdgeInsets widget snippet with symmetric contructor `symmetric` with only vertical parameter": {
+    "prefix": "fedgsymv",
+    "body": [
+      "EdgeInsets.symmetric(vertical: ${1:8.0},)${0}"
+    ],
+    "description": "EdgeInsets widget snippet with named constructor `symmetric` with only vertical parameter"
+  },
+  "EdgeInsets widget snippet with symmetric contructor `symmetric` with only horizontal parameter": {
+    "prefix": "fedgsymh",
+    "body": [
+      "EdgeInsets.symmetric(horizontal: ${1:8.0},)${0}"
+    ],
+    "description": "EdgeInsets widget snippet with named constructor `symmetric` with only horizontal parameter"
   }
 }


### PR DESCRIPTION
Added Snippet for named constructor `EdgeInsets.symmetric` as I use this more frequently when working with Flutter